### PR TITLE
[feat] 마이페이지 찜 목록 조회 API 추가

### DIFF
--- a/backend/products/urls.py
+++ b/backend/products/urls.py
@@ -3,7 +3,8 @@ from . import views
 
 urlpatterns = [
     path("", views.product_list),
+    path("recommend/", views.product_recommend),
+    path("favorites/", views.favorite_list),
     path("<int:product_id>/", views.product_detail),
     path("<int:product_id>/favorite/", views.toggle_favorite),
-    path("recommend/", views.product_recommend),
 ]

--- a/backend/products/views.py
+++ b/backend/products/views.py
@@ -6,6 +6,10 @@ from rest_framework.permissions import IsAuthenticated
 from .models import Product, Favorite, ProductRate
 from .serializers import ProductListSerializer, ProductDetailSerializer, RecommendRequestSerializer, RecommendResponseSerializer
 
+
+# ============================================================
+# - 상품 목록 조회 API
+# ============================================================
 @api_view(["GET"])
 def product_list(request):
     qs = Product.objects.all()
@@ -52,6 +56,9 @@ def product_list(request):
     serializer = ProductListSerializer(qs, many=True)
     return Response(serializer.data)
 
+# ============================================================
+# - 상품 상세 조회 API
+# ============================================================
 @api_view(["GET"])
 def product_detail(request, product_id):
     product = Product.objects.prefetch_related("rates").filter(id=product_id).first()
@@ -62,6 +69,9 @@ def product_detail(request, product_id):
     serializer = ProductDetailSerializer(product)
     return Response(serializer.data)
 
+# ============================================================
+# - 상품 찜 토글 API
+# ============================================================
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def toggle_favorite(request, product_id):
@@ -77,6 +87,9 @@ def toggle_favorite(request, product_id):
     Favorite.objects.create(user=request.user, product=product)
     return Response({"is_favorite":True}, status=status.HTTP_201_CREATED)
 
+# ============================================================
+# - 추천 계산용 유틸 함수
+# ============================================================
 def _calc_expected_amount(principal: float, months: int, rate: float) -> float:
     return principal * (1 + (rate / 100) * (months / 12))
 
@@ -95,6 +108,9 @@ def _score(product: Product, months: int, want_nftf, want_dp) -> int:
     return min(score, 100)
 
 
+# ============================================================
+# - 조건 기반 상품 추천 API
+# ============================================================
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def product_recommend(request):
@@ -152,3 +168,20 @@ def product_recommend(request):
 
     res = RecommendResponseSerializer({"results": results})
     return Response(res.data, status=status.HTTP_200_OK)
+
+# ============================================================
+# - 찜 목록 조회 API (마이페이지용)
+# ============================================================
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def favorite_list(request):
+    favorites = (
+        Favorite.objects
+        .filter(user=request.user)
+        .select_related("product")
+        .order_by("-created_at")
+    )
+
+    products = [fav.product for fav in favorites]
+    serializer = ProductListSerializer(products, many=True)
+    return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## ✅ PR 유형
> 이번 변경 사항은 어떤 종류인가요?

- [x] ✨ 새로운 기능 추가 (Feature)
- [ ] 🐞 버그 수정 (Fix)
- [ ] 🎨 스타일 변경(코드 형식, 세미콜론 추가 등 비기능적 변경)
- [ ] ♻️ 리팩토링 (코드 구조 개선, 변수명 변경 등)
- [ ] 📄 문서 수정 (README, 문서 추가/수정)
- [ ] 🧪 테스트 코드 추가 및 수정
- [ ] 🔧 빌드/환경 설정 변경 (패키지 관리자, 설정파일 등)
- [ ] 🗂 파일/폴더 구조 변경
- [ ] 🔥 파일/폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 어떤 작업을 했는지 상세하게 설명해주세요.

- GET /products/favorites/ 찜 목록 조회 API 추가 (로그인 필수)
- Favorite 모델을 기준으로 최신순 정렬하여 사용자의 찜 상품 리스트 반환
- N+1 방지를 위해 select_related("product") 적용

---

## 🔗 관련 Issue 번호  
> 해당 PR이 연결된 이슈 번호를 적어주세요.  

`Closes #29`

---

## 💬 기타 참고 사항
> 검토자에게 전달할 내용, 구현 중 고민한 부분, 테스트 방법 등이 있다면 적어주세요.

### 테스트 방법 (Postman)

1. /auth/login/으로 access_token 발급
2. Header에 Authorization: Bearer <access_token> 설정
3. GET /products/favorites/ 호출 → 찜한 상품 리스트 반환 확인

마이페이지 찜 목록 프론트 페이지에서 바로 붙일 수 있도록 ProductListSerializer 기반 응답으로 맞춰두었음
